### PR TITLE
Fixing error after last merge request

### DIFF
--- a/CentralDeErros/CentralDeErros.Api/CentralDeErros.Api.csproj
+++ b/CentralDeErros/CentralDeErros.Api/CentralDeErros.Api.csproj
@@ -26,8 +26,8 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.0.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="5.0.0-rc4" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="4.5.5" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="5.0.0-rc5" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="5.0.0-rc5" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Versions of "Swashbuckle.AspNetCore" and "Swashbuckle.AspNetCore.Filters" Must be the same release